### PR TITLE
relx script replaces parametrize cookie and node_name

### DIFF
--- a/core/vm.args
+++ b/core/vm.args
@@ -1,4 +1,4 @@
--setcookie change_me
+-setcookie ${COOKIE}
 
 # Tell SASL not to log progress reports, and log SASL errors to a file
 -sasl errlog_type error
@@ -30,3 +30,4 @@
 
 -s lager
 -s kazoo_apps_app
+-name ${NODE_NAME}

--- a/system/sbin/kazoo-applications
+++ b/system/sbin/kazoo-applications
@@ -1,11 +1,11 @@
 #!/bin/bash
 
 if [ -f /etc/default/kazoo ]; then
-	. /etc/default/kazoo
+    . /etc/default/kazoo
 fi
 
 RETVAL=1
-NAME=kazoo-applications
+NAME=${KAZOO_NAME:-kazoo-applications}
 USER=${KAZOO_USER:-kazoo}
 BIN_FILE=${KAZOO_BIN:-/opt/kazoo/bin/kazoo}
 PID_FILE=${KAZOO_PID:-/var/run/kazoo/${NAME}.pid}
@@ -13,187 +13,199 @@ export HOME=${KAZOO_ROOT:-/opt/kazoo}
 export VMARGS_PATH=${KAZOO_VMARGS:-/etc/kazoo/core/vm.args}
 
 if [ -f /etc/sysconfig/kazoo ]; then
-	. /etc/sysconfig/kazoo
+    . /etc/sysconfig/kazoo
 fi
 
 if [ "${NAME}" == "kazoo-applications" ]; then
-	NAME="kazoo_apps"
+    NAME="kazoo_apps"
 else
-	NAME=${NAME#*-}
+    NAME=${NAME#*-}
 fi
 
-export NAME_ARG="-name ${NAME}"
+export NODE_NAME="${NAME}"
+# Intermediate cookie to start the node,
+# Kazoo will set cookie based on config.ini later
+# All other commands should call `set_cookie` to set
+# correct cookie from running node
+export COOKIE="${COOKIE:-change_me}"
 
 # Detect core count
 CORES=`grep -E "^processor" /proc/cpuinfo |wc -l`
 if [ "${CORES}" = "1" ]; then
-        BEAM=beam
+    BEAM=beam
 else
-        BEAM=beam.smp
+    BEAM=beam.smp
 fi
 
 prepare() {
-	chown -R ${USER} /opt/kazoo /opt/kazoo/.*
-	mkdir -p /tmp/erl_pipes/${NAME}
-	chown -R ${USER} /tmp/erl_pipes/${NAME}
-	mkdir -p /var/log/kazoo
-	chown -R ${USER} /var/log/kazoo
-	mkdir -p /var/run/kazoo
-	chown -R ${USER} /var/run/kazoo
-	if [ -e ${PID_FILE} ]; then
-		rm -rf ${PID_FILE}
-	fi
-        RETVAL=$?
+    chown -R ${USER} /opt/kazoo /opt/kazoo/.*
+    mkdir -p /tmp/erl_pipes/${NAME}
+    chown -R ${USER} /tmp/erl_pipes/${NAME}
+    mkdir -p /var/log/kazoo
+    chown -R ${USER} /var/log/kazoo
+    mkdir -p /var/run/kazoo
+    chown -R ${USER} /var/run/kazoo
+    if [ -e ${PID_FILE} ]; then
+        rm -rf ${PID_FILE}
+    fi
+    RETVAL=$?
 }
 
 start() {
-	cd ${HOME}
+    cd ${HOME}
 
-	if sudo -E -u ${USER} ${BIN_FILE} pid > /dev/null 2>&1; then
-		echo "Kazoo ${NAME} is already running!"
-		return
-	fi
+    if sudo -E -u ${USER} ${BIN_FILE} pid > /dev/null 2>&1; then
+        echo "Kazoo ${NAME} is already running!"
+        return
+    fi
 
-	export CODE_LOADING_MODE=interactive
-	export ERL_CRASH_DUMP=/var/log/kazoo/$(date +%s)_erl_crash.dump
-	set -- ${BIN_FILE} "$@"
-	if [ "$(whoami)" == "${USER}" ]; then
-		exec "$@"
-	else
-		runuser -s /bin/bash ${USER} -c "$*"
-	fi
-	RETVAL=$?
+    export CODE_LOADING_MODE=interactive
+    export ERL_CRASH_DUMP="/var/log/kazoo/$(date +%s)_${NAME}_erl_crash.dump"
+    set_relx_eviroment_vars
+    set -- ${BIN_FILE} "$@"
+    if [ "$(whoami)" == "${USER}" ]; then
+        exec "$@"
+    else
+        runuser -s /bin/bash ${USER} -c "$*"
+    fi
+    RETVAL=$?
 
-	if [ ${RETVAL} -ne 0 ]; then
-		echo "Failed to start Kazoo ${NAME}!"
-		RETVAL=1
-	fi
+    if [ ${RETVAL} -ne 0 ]; then
+        echo "Failed to start Kazoo ${NAME}!"
+        RETVAL=1
+    fi
 }
 
 stop() {
-        for i in `pidof ${BEAM}`; do
-                if cat /proc/$i/cmdline | grep -Eq "name[^\-]+${NAME}"; then
-                        kill $i
-                        RETVAL=$?
-                fi
-        done
+    for i in `pidof ${BEAM}`; do
+        if cat /proc/$i/cmdline | grep -Eq "name[^\-]+${NAME}"; then
+            kill $i
+            RETVAL=$?
+        fi
+    done
 }
 
 restart() {
-	stop
-	start
+    stop
+    start
 }
 
 status() {
-	cd ${HOME}
-        for i in `pidof ${BEAM}`; do
-                if cat /proc/$i/cmdline | grep -Eq "name[^\-]+${NAME}"; then
-			set_cookie_arg
-			/usr/sbin/sup -n ${NAME} kz_nodes status
-			RETVAL=$?
-		fi
-	done
-        if [ ${RETVAL} -eq 1 ]; then
-                echo "${NAME} is not running!"
+    cd ${HOME}
+    for i in `pidof ${BEAM}`; do
+        if cat /proc/$i/cmdline | grep -Eq "name[^\-]+${NAME}"; then
+            /usr/sbin/sup -n ${NAME} kz_nodes status
+            RETVAL=$?
         fi
+    done
+    if [ ${RETVAL} -eq 1 ]; then
+        echo "${NAME} is not running!"
+    fi
 }
 
 connect() {
-	cd ${HOME}
-        for i in `pidof ${BEAM}`; do
-                if cat /proc/$i/cmdline | grep -Eq "name[^\-]+${NAME}"; then
-			set_cookie_arg
-			sudo -E -u ${USER} ${BIN_FILE} remote_console
-			RETVAL=$?
-		fi
-	done
-        if [ ${RETVAL} -eq 1 ]; then
-                echo "${NAME} is not running!"
+    cd ${HOME}
+    for i in `pidof ${BEAM}`; do
+        if cat /proc/$i/cmdline | grep -Eq "name[^\-]+${NAME}"; then
+            set_relx_eviroment_vars
+            set_cookie
+            sudo -E -u ${USER} ${BIN_FILE} remote_console
+            RETVAL=$?
         fi
+    done
+    if [ ${RETVAL} -eq 1 ]; then
+        echo "${NAME} is not running!"
+    fi
 }
 
 attach() {
-	cd ${HOME}
-        for i in `pidof ${BEAM}`; do
-                if cat /proc/$i/cmdline | grep -Eq "name[^\-]+${NAME}"; then
-			set_cookie_arg
-			echo "WARNING: You are now directly attached to the running ${NAME} Erlang node."
-			echo "   It is safer to use: $0 connect"
-			sudo -E -u ${USER} ${BIN_FILE} attach
-			RETVAL=$?
-		fi
-	done
-        if [ ${RETVAL} -eq 1 ]; then
-                echo "${NAME} is not running!"
+    cd ${HOME}
+    for i in `pidof ${BEAM}`; do
+        if cat /proc/$i/cmdline | grep -Eq "name[^\-]+${NAME}"; then
+            set_relx_eviroment_vars
+            set_cookie
+            echo "WARNING: You are now directly attached to the running ${NAME} Erlang node."
+            echo "   It is safer to use: $0 connect"
+            sudo -E -u ${USER} ${BIN_FILE} attach
+            RETVAL=$?
         fi
+    done
+    if [ ${RETVAL} -eq 1 ]; then
+        echo "${NAME} is not running!"
+    fi
 }
 
-ping() {
-	cd ${HOME}
-        for i in `pidof ${BEAM}`; do
-                if cat /proc/$i/cmdline | grep -Eq "name[^\-]+${NAME}"; then
-			set_cookie_arg
-			sudo -E -u ${USER} ${BIN_FILE} ping
-			RETVAL=$?
-		fi
-	done
-        if [ ${RETVAL} -eq 1 ]; then
-                echo "${NAME} is not running!"
+ping_node() {
+    cd ${HOME}
+    for i in `pidof ${BEAM}`; do
+        if cat /proc/$i/cmdline | grep -Eq "name[^\-]+${NAME}"; then
+            set_relx_eviroment_vars
+            set_cookie
+            sudo -E -u ${USER} ${BIN_FILE} ping
+            RETVAL=$?
         fi
+    done
+    if [ ${RETVAL} -eq 1 ]; then
+        echo "${NAME} is not running!"
+    fi
 }
 
 pid() {
-	cd ${HOME}
-        for i in `pidof ${BEAM}`; do
-                if cat /proc/$i/cmdline | grep -Eq "name[^\-]+${NAME}"; then
-			echo $i
-                        RETVAL=0
-                fi
-        done
-        if [ ${RETVAL} -eq 1 ]; then
-                echo "${NAME} is not running!"
+    cd ${HOME}
+    for i in `pidof ${BEAM}`; do
+        if cat /proc/$i/cmdline | grep -Eq "name[^\-]+${NAME}"; then
+            echo $i
+            RETVAL=0
         fi
+    done
+    if [ ${RETVAL} -eq 1 ]; then
+         echo "${NAME} is not running!"
+    fi
 }
 
-set_cookie_arg() {
-	COOKIE=`/usr/sbin/sup -n ${NAME} erlang get_cookie | sed "s|'||g"`
-	export COOKIE_ARG="-setcookie ${COOKIE}"
-	RETVAL=$?
+set_relx_eviroment_vars() {
+    export RELX_REPLACE_OS_VARS=true
+    export RELX_MULTI_NODE=true
+}
+
+set_cookie() {
+    export COOKIE=`/usr/sbin/sup -n ${NAME} erlang get_cookie | sed "s|'||g"`
+    RETVAL=$?
 }
 
 case "$1" in
-	prepare)
-		prepare
-		;;
-	background)
-		start "start"
-		;;
-	start)
-		start "foreground"
-		;;
-	stop)
-		stop
-		;;
-	restart)
-		restart
-		;;
-	status)
-		status
-		;;
-	connect)
-		connect
-		;;
-	attach)
-		attach
-		;;
-	ping)
-		ping
-		;;
-	pid)
-		pid
-		;;
-	*)
-		echo "Usage: $0 (prepare|start|background|stop|restart|status|connect|attach|ping|pid)"
+    prepare)
+        prepare
+        ;;
+    background)
+        start "start"
+        ;;
+    start)
+        start "foreground"
+        ;;
+    stop)
+        stop
+        ;;
+    restart)
+        restart
+        ;;
+    status)
+        status
+        ;;
+    connect)
+        connect
+        ;;
+    attach)
+        attach
+        ;;
+    ping)
+        ping_node
+        ;;
+    pid)
+        pid
+        ;;
+    *)
+        echo "Usage: $0 (prepare|start|background|stop|restart|status|connect|attach|ping|pid)"
 esac
 
 exit ${RETVAL}

--- a/system/sbin/kazoo-ecallmgr
+++ b/system/sbin/kazoo-ecallmgr
@@ -1,11 +1,11 @@
 #!/bin/bash
 
 if [ -f /etc/default/kazoo ]; then
-	. /etc/default/kazoo
+    . /etc/default/kazoo
 fi
 
 RETVAL=1
-NAME=kazoo-ecallmgr
+NAME=${KAZOO_NAME:-kazoo-ecallmgr}
 USER=${KAZOO_USER:-kazoo}
 BIN_FILE=${KAZOO_BIN:-/opt/kazoo/bin/kazoo}
 PID_FILE=${KAZOO_PID:-/var/run/kazoo/${NAME}.pid}
@@ -13,185 +13,199 @@ export HOME=${KAZOO_ROOT:-/opt/kazoo}
 export VMARGS_PATH=${KAZOO_VMARGS:-/etc/kazoo/core/vm.args}
 
 if [ -f /etc/sysconfig/kazoo ]; then
-	. /etc/sysconfig/kazoo
+    . /etc/sysconfig/kazoo
 fi
 
 if [ "${NAME}" == "kazoo-applications" ]; then
-	NAME="kazoo_apps"
+    NAME="kazoo_apps"
 else
-	NAME=${NAME#*-}
+    NAME=${NAME#*-}
 fi
 
-export NAME_ARG="-name ${NAME}"
+export NODE_NAME="${NAME}"
+# Intermediate cookie to start the node,
+# Kazoo will set cookie based on config.ini later
+# All other commands should call `set_cookie` to set
+# correct cookie from running node
+export COOKIE="${COOKIE:-change_me}"
 
 # Detect core count
 CORES=`grep -E "^processor" /proc/cpuinfo |wc -l`
 if [ "${CORES}" = "1" ]; then
-        BEAM=beam
+    BEAM=beam
 else
-        BEAM=beam.smp
+    BEAM=beam.smp
 fi
 
 prepare() {
-	chown -R ${USER} /opt/kazoo /opt/kazoo/.*
-	mkdir -p /tmp/erl_pipes/${NAME}
-	chown -R ${USER} /tmp/erl_pipes/${NAME}
-	mkdir -p /var/log/kazoo
-	chown -R ${USER} /var/log/kazoo
-	mkdir -p /var/run/kazoo
-	chown -R ${USER} /var/run/kazoo
-	if [ -e ${PID_FILE} ]; then
-		rm -rf ${PID_FILE}
-	fi
-	RETVAL=$?
+    chown -R ${USER} /opt/kazoo /opt/kazoo/.*
+    mkdir -p /tmp/erl_pipes/${NAME}
+    chown -R ${USER} /tmp/erl_pipes/${NAME}
+    mkdir -p /var/log/kazoo
+    chown -R ${USER} /var/log/kazoo
+    mkdir -p /var/run/kazoo
+    chown -R ${USER} /var/run/kazoo
+    if [ -e ${PID_FILE} ]; then
+        rm -rf ${PID_FILE}
+    fi
+    RETVAL=$?
 }
 
 start() {
-	cd ${HOME}
+    cd ${HOME}
 
-	if sudo -E -u ${USER} ${BIN_FILE} pid > /dev/null 2>&1; then
-		echo "Kazoo ${NAME} is already running!"
-		return
-	fi
+    if sudo -E -u ${USER} ${BIN_FILE} pid > /dev/null 2>&1; then
+        echo "Kazoo ${NAME} is already running!"
+        return
+    fi
 
-	export CODE_LOADING_MODE=interactive
-	set -- ${BIN_FILE} "$@"
-	if [ "$(whoami)" == "${USER}" ]; then
-		exec "$@"
-	else
-		runuser -s /bin/bash ${USER} -c "$*"
-	fi
-	RETVAL=$?
+    export CODE_LOADING_MODE=interactive
+    export ERL_CRASH_DUMP="/var/log/kazoo/$(date +%s)_${NAME}_erl_crash.dump"
+    set_relx_eviroment_vars
+    set -- ${BIN_FILE} "$@"
+    if [ "$(whoami)" == "${USER}" ]; then
+        exec "$@"
+    else
+        runuser -s /bin/bash ${USER} -c "$*"
+    fi
+    RETVAL=$?
 
-	if [ ${RETVAL} -ne 0 ]; then
-		echo "Failed to start Kazoo ${NAME}!"
-		RETVAL=1
-	fi
+    if [ ${RETVAL} -ne 0 ]; then
+        echo "Failed to start Kazoo ${NAME}!"
+        RETVAL=1
+    fi
 }
 
 stop() {
-        for i in `pidof ${BEAM}`; do
-                if cat /proc/$i/cmdline | grep -Eq "name[^\-]+${NAME}"; then
-                        kill $i
-                        RETVAL=$?
-                fi
-        done
+    for i in `pidof ${BEAM}`; do
+        if cat /proc/$i/cmdline | grep -Eq "name[^\-]+${NAME}"; then
+            kill $i
+            RETVAL=$?
+        fi
+    done
 }
 
 restart() {
-	stop
-	start
+    stop
+    start
 }
 
 status() {
-	cd ${HOME}
-        for i in `pidof ${BEAM}`; do
-                if cat /proc/$i/cmdline | grep -Eq "name[^\-]+${NAME}"; then
-			set_cookie_arg
-			/usr/sbin/sup -n ${NAME} kz_nodes status
-			RETVAL=$?
-		fi
-	done
-        if [ ${RETVAL} -eq 1 ]; then
-                echo "${NAME} is not running!"
+    cd ${HOME}
+    for i in `pidof ${BEAM}`; do
+        if cat /proc/$i/cmdline | grep -Eq "name[^\-]+${NAME}"; then
+            /usr/sbin/sup -n ${NAME} kz_nodes status
+            RETVAL=$?
         fi
+    done
+    if [ ${RETVAL} -eq 1 ]; then
+        echo "${NAME} is not running!"
+    fi
 }
 
 connect() {
-	cd ${HOME}
-        for i in `pidof ${BEAM}`; do
-                if cat /proc/$i/cmdline | grep -Eq "name[^\-]+${NAME}"; then
-			set_cookie_arg
-			sudo -E -u ${USER} ${BIN_FILE} remote_console
-			RETVAL=$?
-		fi
-	done
-        if [ ${RETVAL} -eq 1 ]; then
-                echo "${NAME} is not running!"
+    cd ${HOME}
+    for i in `pidof ${BEAM}`; do
+        if cat /proc/$i/cmdline | grep -Eq "name[^\-]+${NAME}"; then
+            set_relx_eviroment_vars
+            set_cookie
+            sudo -E -u ${USER} ${BIN_FILE} remote_console
+            RETVAL=$?
         fi
+    done
+    if [ ${RETVAL} -eq 1 ]; then
+        echo "${NAME} is not running!"
+    fi
 }
 
 attach() {
-	cd ${HOME}
-        for i in `pidof ${BEAM}`; do
-                if cat /proc/$i/cmdline | grep -Eq "name[^\-]+${NAME}"; then
-			set_cookie_arg
-			echo "WARNING: You are now directly attached to the running ${NAME} Erlang node."
-			echo "   It is safer to use: $0 connect"
-			sudo -E -u ${USER} ${BIN_FILE} attach
-			RETVAL=$?
-		fi
-	done
-        if [ ${RETVAL} -eq 1 ]; then
-                echo "${NAME} is not running!"
+    cd ${HOME}
+    for i in `pidof ${BEAM}`; do
+        if cat /proc/$i/cmdline | grep -Eq "name[^\-]+${NAME}"; then
+            set_relx_eviroment_vars
+            set_cookie
+            echo "WARNING: You are now directly attached to the running ${NAME} Erlang node."
+            echo "   It is safer to use: $0 connect"
+            sudo -E -u ${USER} ${BIN_FILE} attach
+            RETVAL=$?
         fi
+    done
+    if [ ${RETVAL} -eq 1 ]; then
+        echo "${NAME} is not running!"
+    fi
 }
 
-ping() {
-	cd ${HOME}
-        for i in `pidof ${BEAM}`; do
-                if cat /proc/$i/cmdline | grep -Eq "name[^\-]+${NAME}"; then
-			set_cookie_arg
-			sudo -E -u ${USER} ${BIN_FILE} ping
-			RETVAL=$?
-		fi
-	done
-        if [ ${RETVAL} -eq 1 ]; then
-                echo "${NAME} is not running!"
+ping_node() {
+    cd ${HOME}
+    for i in `pidof ${BEAM}`; do
+        if cat /proc/$i/cmdline | grep -Eq "name[^\-]+${NAME}"; then
+            set_relx_eviroment_vars
+            set_cookie
+            sudo -E -u ${USER} ${BIN_FILE} ping
+            RETVAL=$?
         fi
+    done
+    if [ ${RETVAL} -eq 1 ]; then
+        echo "${NAME} is not running!"
+    fi
 }
 
 pid() {
-	cd ${HOME}
-        for i in `pidof ${BEAM}`; do
-                if cat /proc/$i/cmdline | grep -Eq "name[^\-]+${NAME}"; then
-			echo $i
-                        RETVAL=0
-                fi
-        done
-        if [ ${RETVAL} -eq 1 ]; then
-                echo "${NAME} is not running!"
+    cd ${HOME}
+    for i in `pidof ${BEAM}`; do
+        if cat /proc/$i/cmdline | grep -Eq "name[^\-]+${NAME}"; then
+            echo $i
+            RETVAL=0
         fi
+    done
+    if [ ${RETVAL} -eq 1 ]; then
+         echo "${NAME} is not running!"
+    fi
 }
 
-set_cookie_arg() {
-	COOKIE=`/usr/sbin/sup -n ${NAME} erlang get_cookie | sed "s|'||g"`
-	export COOKIE_ARG="-setcookie ${COOKIE}"
+set_relx_eviroment_vars() {
+    export RELX_REPLACE_OS_VARS=true
+    export RELX_MULTI_NODE=true
+}
+
+set_cookie() {
+    export COOKIE=`/usr/sbin/sup -n ${NAME} erlang get_cookie | sed "s|'||g"`
+    RETVAL=$?
 }
 
 case "$1" in
-	prepare)
-		prepare
-		;;
-	background)
-		start "start"
-		;;
-	start)
-		start "foreground"
-		;;
-	stop)
-		stop
-		;;
-	restart)
-		restart
-		;;
-	status)
-		status
-		;;
-	connect)
-		connect
-		;;
-	attach)
-		attach
-		;;
-	ping)
-		ping
-		;;
-	pid)
-		pid
-		;;
-	*)
-		echo "Usage: $0 (prepare|start|background|stop|restart|status|connect|attach|ping|pid)"
+    prepare)
+        prepare
+        ;;
+    background)
+        start "start"
+        ;;
+    start)
+        start "foreground"
+        ;;
+    stop)
+        stop
+        ;;
+    restart)
+        restart
+        ;;
+    status)
+        status
+        ;;
+    connect)
+        connect
+        ;;
+    attach)
+        attach
+        ;;
+    ping)
+        ping_node
+        ;;
+    pid)
+        pid
+        ;;
+    *)
+        echo "Usage: $0 (prepare|start|background|stop|restart|status|connect|attach|ping|pid)"
 esac
 
 exit ${RETVAL}


### PR DESCRIPTION
* use env vars to replace cookie and name in the new relx scripts
* formatting start up scripts
* add node name to ERL_CRASH_DUMP
* change ping function to ping_node to avoid confusion

**Depends** on https://github.com/2600hz/kazoo/pull/3907 (for master)
**Depends** on https://github.com/2600hz/kazoo/pull/3911 (for 4.0)