### PR TITLE
Kazoo startup script takes ownership of /opt

### DIFF
--- a/system/sbin/kazoo-applications
+++ b/system/sbin/kazoo-applications
@@ -40,7 +40,7 @@ fi
 prepare() {
     rm -f /etc/kazoo/core/vm.args.orig
     chown ${USER} /etc/kazoo/core
-    chown -R ${USER} /opt/kazoo /opt/kazoo/.*
+    chown -R ${USER} /opt/kazoo
     mkdir -p /tmp/erl_pipes/${NAME}
     chown -R ${USER} /tmp/erl_pipes/${NAME}
     mkdir -p /var/log/kazoo

--- a/system/sbin/kazoo-ecallmgr
+++ b/system/sbin/kazoo-ecallmgr
@@ -40,7 +40,7 @@ fi
 prepare() {
     rm -f /etc/kazoo/core/vm.args.orig
     chown ${USER} /etc/kazoo/core
-    chown -R ${USER} /opt/kazoo /opt/kazoo/.*
+    chown -R ${USER} /opt/kazoo
     mkdir -p /tmp/erl_pipes/${NAME}
     chown -R ${USER} /tmp/erl_pipes/${NAME}
     mkdir -p /var/log/kazoo


### PR DESCRIPTION
The Kazoo startup script takes ownership of /opt when it should only take ownership of /opt/kazoo. This interferes with the ability of CouchDB 2.0 to modify its configuration, which prevents the UI from working. The script replaces recursive ownership of /opt with recursive ownership of /opt/kazoo.