### PR TITLE
HELP-34245: Fixed sudoers commands running on non-sudo user when executed by systemd

### DIFF
--- a/system/sbin/kazoo-applications
+++ b/system/sbin/kazoo-applications
@@ -44,7 +44,7 @@ prepare() {
 start() {
     cd ${HOME}
 
-    if sudo -E -u ${USER} ${BIN_FILE} pid > /dev/null 2>&1; then
+    if bg_bin_cmd pid; then
         echo "Kazoo ${NAME} is already running!"
         return
     fi
@@ -101,7 +101,7 @@ connect() {
     for i in `pidof ${BEAM}`; do
         if cat /proc/$i/cmdline | grep -Eq "name[^\-]+${NAME}"; then
             set_cookie
-            sudo -E -u ${USER} ${BIN_FILE} remote_console
+            fg_bin_cmd remote_console
             RETVAL=$?
         fi
     done
@@ -117,7 +117,7 @@ attach() {
             set_cookie
             echo "WARNING: You are now directly attached to the running ${NAME} Erlang node."
             echo "   It is safer to use: $0 connect"
-            sudo -E -u ${USER} ${BIN_FILE} attach
+            fg_bin_cmd attach
             RETVAL=$?
         fi
     done
@@ -131,7 +131,7 @@ ping_node() {
     for i in `pidof ${BEAM}`; do
         if cat /proc/$i/cmdline | grep -Eq "name[^\-]+${NAME}"; then
             set_cookie
-            sudo -E -u ${USER} ${BIN_FILE} ping
+            fg_bin_cmd ping
             RETVAL=$?
         fi
     done
@@ -156,6 +156,24 @@ pid() {
 set_cookie() {
     export KAZOO_COOKIE=`/usr/sbin/sup -n ${NAME} erlang get_cookie | sed "s|'||g"`
     RETVAL=$?
+}
+
+bg_bin_cmd() {
+    if [ $(whoami) != ${USER} ]; then
+        sudo -E -u ${USER} ${BIN_FILE} $@ > /dev/null 2>&1
+    else
+        ${BIN_FILE} $@ > /dev/null 2>&1
+    fi 
+    return $?
+}
+
+fg_bin_cmd() {
+    if [ $(whoami) != ${USER} ]; then
+        sudo -E -u ${USER} ${BIN_FILE} $@
+    else
+        ${BIN_FILE} $@
+    fi 
+    return $?
 }
 
 case "$1" in

--- a/system/sbin/kazoo-ecallmgr
+++ b/system/sbin/kazoo-ecallmgr
@@ -44,7 +44,7 @@ prepare() {
 start() {
     cd ${HOME}
 
-    if sudo -E -u ${USER} ${BIN_FILE} pid > /dev/null 2>&1; then
+    if bg_bin_cmd; then
         echo "Kazoo ${NAME} is already running!"
         return
     fi
@@ -101,7 +101,7 @@ connect() {
     for i in `pidof ${BEAM}`; do
         if cat /proc/$i/cmdline | grep -Eq "name[^\-]+${NAME}"; then
             set_cookie
-            sudo -E -u ${USER} ${BIN_FILE} remote_console
+            fg_bin_cmd remote_console
             RETVAL=$?
         fi
     done
@@ -117,7 +117,7 @@ attach() {
             set_cookie
             echo "WARNING: You are now directly attached to the running ${NAME} Erlang node."
             echo "   It is safer to use: $0 connect"
-            sudo -E -u ${USER} ${BIN_FILE} attach
+            fg_bin_cmd attach
             RETVAL=$?
         fi
     done
@@ -131,7 +131,7 @@ ping_node() {
     for i in `pidof ${BEAM}`; do
         if cat /proc/$i/cmdline | grep -Eq "name[^\-]+${NAME}"; then
             set_cookie
-            sudo -E -u ${USER} ${BIN_FILE} ping
+            fg_bin_cmd ping
             RETVAL=$?
         fi
     done
@@ -157,6 +157,25 @@ set_cookie() {
     export KAZOO_COOKIE=`/usr/sbin/sup -n ${NAME} erlang get_cookie | sed "s|'||g"`
     RETVAL=$?
 }
+
+bg_bin_cmd() {
+    if [ $(whoami) != ${USER} ]; then
+        sudo -E -u ${USER} ${BIN_FILE} $@ > /dev/null 2>&1
+    else
+        ${BIN_FILE} $@ > /dev/null 2>&1
+    fi
+    return $?
+}
+
+fg_bin_cmd() {
+    if [ $(whoami) != ${USER} ]; then
+        sudo -E -u ${USER} ${BIN_FILE} $@
+    else
+        ${BIN_FILE} $@
+    fi
+    return $?
+}
+
 
 case "$1" in
     prepare)


### PR DESCRIPTION
Because systemd runs the kazoo-applications command as the kazoo user, if you restart kazoo-applications via systemctl it will throw the following error in the journal logs. 

Feb 07 21:56:04 apps001.nyc.testkazoo.com sudo[26475]:    kazoo : user NOT in sudoers ; TTY=unknown ; PWD=/opt/kazoo ; USER=kazoo ; COMMAND=/opt/kazoo/bin/kazoo pid

This fix selectively runs sudo ONLY when the user is not kazoo. 
