### PR TITLE
try stopping nicely first

### DIFF
--- a/system/sbin/kazoo-applications
+++ b/system/sbin/kazoo-applications
@@ -74,8 +74,12 @@ start() {
 stop() {
     for i in `pidof ${BEAM}`; do
         if cat /proc/$i/cmdline | grep -Eq "name[^\-]+${NAME}"; then
-            kill $i
+            timeout 10 /usr/sbin/sup -n ${NAME} init stop
             RETVAL=$?
+            if [ ${RETVAL} -neq 0 ]; then
+                kill $i
+                RETVAL=$?
+            fi
         fi
     done
 }

--- a/system/sbin/kazoo-ecallmgr
+++ b/system/sbin/kazoo-ecallmgr
@@ -74,8 +74,12 @@ start() {
 stop() {
     for i in `pidof ${BEAM}`; do
         if cat /proc/$i/cmdline | grep -Eq "name[^\-]+${NAME}"; then
-            kill $i
+            timeout 10 /usr/sbin/sup -n ${NAME} init stop
             RETVAL=$?
+            if [ ${RETVAL} -neq 0 ]; then
+                kill $i
+                RETVAL=$?
+            fi
         fi
     done
 }


### PR DESCRIPTION
I think the `kill` is causing crash dumps which is alarming folks and unnecessary. This will try an orderly shutdown for 10s first, then kill if necessary.