### PR TITLE
KZOO-108: Do not decide BEAM process based on core count

### DIFF
--- a/system/sbin/kazoo-applications
+++ b/system/sbin/kazoo-applications
@@ -23,13 +23,7 @@ fi
 
 export KAZOO_NODE="${NAME}"
 
-# Detect core count
-CORES=`grep -E "^processor" /proc/cpuinfo |wc -l`
-if [ "${CORES}" = "1" ]; then
-    BEAM=beam
-else
-    BEAM=beam.smp
-fi
+BEAM='beam beam.smp'
 
 prepare() {
     rm -f /etc/kazoo/core/vm*.args

--- a/system/sbin/kazoo-ecallmgr
+++ b/system/sbin/kazoo-ecallmgr
@@ -23,13 +23,7 @@ fi
 
 export KAZOO_NODE="${NAME}"
 
-# Detect core count
-CORES=`grep -E "^processor" /proc/cpuinfo |wc -l`
-if [ "${CORES}" = "1" ]; then
-    BEAM=beam
-else
-    BEAM=beam.smp
-fi
+BEAM='beam beam.smp'
 
 prepare() {
     rm -f /etc/kazoo/core/vm*.args


### PR DESCRIPTION
SMP does not only depend on the numbers of cores on the running system, but it
also depends on the flags passed to the Erlang VM when starting it so let us
just get the pids for both `beam` and `beam.smp` processes and let the code
filter/search (grep) for the desired VM as it is already doing.

Prior to this change kazoo-[applications, ecallmgr] executables were failing
when running on single core systems because it seems Erlang comes with SMP
enabled by default and we don't check how many cores does the system has when
starting our VMs so they are running with SMP enabled even on single core machines
and that will brake the aforementioned executables because they would try to find
pid for `beam` processes but again since they have SMP enabled they are `beam.smp`,
thus, they will not be found and they will just reply: `DESIRED_APP is not running`.