### PR TITLE
Create world writable `/tmp/erl_pipes` dir in `prepare()`

### DIFF
--- a/system/sbin/kazoo-applications
+++ b/system/sbin/kazoo-applications
@@ -29,8 +29,8 @@ prepare() {
     rm -f /etc/kazoo/core/vm*.args
     chown ${USER} /etc/kazoo/core
     chown -R ${USER} /opt/kazoo
-    mkdir -p /tmp/erl_pipes/${NAME}
-    chown -R ${USER} /tmp/erl_pipes/${NAME}
+    mkdir -p /tmp/erl_pipes
+    chmod a=rwx /tmp/erl_pipes 2> /dev/null
     mkdir -p /var/log/kazoo
     chown -R ${USER} /var/log/kazoo
     mkdir -p /var/run/kazoo

--- a/system/sbin/kazoo-ecallmgr
+++ b/system/sbin/kazoo-ecallmgr
@@ -29,8 +29,8 @@ prepare() {
     rm -f /etc/kazoo/core/vm*.args
     chown ${USER} /etc/kazoo/core
     chown -R ${USER} /opt/kazoo
-    mkdir -p /tmp/erl_pipes/${NAME}
-    chown -R ${USER} /tmp/erl_pipes/${NAME}
+    mkdir -p /tmp/erl_pipes
+    chmod a=rwx /tmp/erl_pipes 2> /dev/null
     mkdir -p /var/log/kazoo
     chown -R ${USER} /var/log/kazoo
     mkdir -p /var/run/kazoo


### PR DESCRIPTION
If `kazoo-applications prepare` is run by root, `/tmp/erl_pipes` was previously created with a mode that disallows kazoo to create its pipe dir. The pipe dir created in `prepare()` wasn't the correct one anyway - it was missing the hostname which is added by relx in `relx_get_hostname`. So, create a world writable `/tmp/erl_pipes` dir regardless of the user executing `prepare()` to allow the relx start script to create its own (private/non-world accessible) pipe dir.

stderr for the `chmod` call is suppressed in the case such as root having created `/tmp/erl_pipes` in the first place and the kazoo user running `prepare()`